### PR TITLE
🐛 Fixing: Incompatible block pointer types Error on iOS

### DIFF
--- a/ios/VisionCameraBase64Plugin.m
+++ b/ios/VisionCameraBase64Plugin.m
@@ -5,11 +5,12 @@
 
 @implementation Plugins
 
-    + (void) load {
-        [FrameProcessorPluginRegistry addFrameProcessorPlugin:@"frameToBase64"
-                                              withInitializer:^FrameProcessorPlugin*(NSDictionary* options) {
-            return [[VisionCameraBase64Plugin alloc] init];
-        }];
-    }
++ (void)load {
+    [FrameProcessorPluginRegistry addFrameProcessorPlugin:@"frameToBase64"
+                                          withInitializer:^FrameProcessorPlugin * _Nonnull (VisionCameraProxyHolder * _Nonnull cameraProxy, NSDictionary * _Nullable options) {
+
+        return [[VisionCameraBase64Plugin alloc] initWithProxy:cameraProxy withOptions:options];
+    }];
+}
 
 @end


### PR DESCRIPTION
As the name suggest this PR fixes the error while building on iOS.

Also closes the issue #2 